### PR TITLE
👷 ci: mainブランチへのPRをdevlopブランチのみに制限(#5)

### DIFF
--- a/.github/workflows/branch_restrictions.yml
+++ b/.github/workflows/branch_restrictions.yml
@@ -1,0 +1,18 @@
+name: Branch Restrictions
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_base_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from a branch with 'develop' in its name
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          if [[ ! "$BRANCH" == *develop* ]]; then
+            echo "Error: PRs to main must come from a branch that includes 'develop' in its name."
+            exit 1
+          fi


### PR DESCRIPTION
## 関連：issue・Ticket
#5 
## 概要

(やったことを書く)
mainブランチにPRを作成する際にbranch名に{develop}が含まれていない場合にエラーを返すworkflowを作成

## 変更点

- workflows/branch_restrictions.ymlを作成
-

## セルフチェック観点

- [ ] テストの導入
- [ ] buildの確認
- [ ] StorybookでのUI確認

## 今後やること

- [ ] 
- [ ]
- [ ]

## UIの変更

(UIに関する変更がある場合は、スクリーンショットを貼り付ける)
| ファイル名 | 変更前 | 変更後 |
| --- | --- | --- |
| | | |
| | | |
| | | |

## 参考

(参考になった文献などがあれば貼り付ける)
