### PR TITLE
✨ feature: ServiceContentsセクションの作成 #21

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -13,6 +13,11 @@
       "rules": {
         "any-rule": false
       }
+    },
+    "src/components/ui/*": {
+      "rules": {
+        "any-rule": false
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/jest": "^29.5.12",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "lucide-react": "^0.358.0",
         "next": "14.1.3",
         "react": "^18",
         "react-dom": "^18",
@@ -15096,6 +15097,14 @@
       "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.358.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.358.0.tgz",
+      "integrity": "sha512-rBSptRjZTMBm24zsFhR6pK/NgbT18JegZGKcH4+1H3+UigMSRpeoWLtR/fAwMYwYnlJOZB+y8WpeHne9D6X6Kg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/jest": "^29.5.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "lucide-react": "^0.358.0",
     "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/_components/Common/Header/Header.tsx
+++ b/src/app/_components/Common/Header/Header.tsx
@@ -5,11 +5,11 @@ export const Header: FC = () => {
   return (
     <div className="h-[800px] w-full bg-gradient-custom">
       <div className="flex flex-col px-40 py-64">
-        <h1 className="text-start font-ZenOldMincho text-xl font-bold text-white">
-          「創意」<span className="text-lg">と</span>「誠意」<span className="pr-4 text-lg">で</span> <br />
+        <h1 className="text-start font-ZenOldMincho text-2xl font-bold text-white">
+          「創意」<span className="text-xl">と</span>「誠意」<span className="pr-4 text-xl">で</span> <br />
           <span className="pl-16">真心奉仕</span>
         </h1>
-        <h2 className="px-14  py-6 text-lg font-bold text-white">
+        <h2 className="px-14  py-6 text-xl font-bold text-white">
           機能工具と関連機器の販売から加工、
           <br />
           制作まで幅広く扱います

--- a/src/app/_components/Common/NavigationBar/NavigationBarPresenter.tsx
+++ b/src/app/_components/Common/NavigationBar/NavigationBarPresenter.tsx
@@ -10,12 +10,12 @@ type NavigationBar = {
 
 export const NavigationBarPresenter: FC<NavigationBar> = (props) => {
   return (
-    <nav className="fixed z-20 w-full bg-nav shadow-md">
+    <nav className="fixed z-20 w-full border-b-2 bg-nav shadow-lg">
       <div className="mx-16 flex items-center justify-between py-4">
         {/* 左サイド */}
         <Link className="flex items-center justify-center space-x-6" href={'#'}>
           {props.logo}
-          <h1 className="text-lg font-extrabold">{props.companyName}</h1>
+          <h1 className="text-xl font-extrabold">{props.companyName}</h1>
         </Link>
         {/* 右サイド */}
         <div className="flex items-center space-x-10">

--- a/src/app/_components/Common/ServiceContent/ServiceContent.stories.tsx
+++ b/src/app/_components/Common/ServiceContent/ServiceContent.stories.tsx
@@ -1,4 +1,6 @@
-import { ServiceContent } from './ServiceContent'
+import { Wrench } from 'lucide-react'
+
+import { ServiceContent, ServiceContentProps } from './ServiceContent'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -10,6 +12,17 @@ export default {
 
 type Story = StoryObj<T>
 
+const serviceContent: ServiceContentProps = {
+  icon: <Wrench />,
+  content: (
+    <p>
+      機械工具及び省力化機器
+      <br />
+      伝動機器の販売
+    </p>
+  )
+}
+
 export const Default: Story = {
-  args: {}
+  args: { ...serviceContent }
 }

--- a/src/app/_components/Common/ServiceContent/ServiceContent.test.tsx
+++ b/src/app/_components/Common/ServiceContent/ServiceContent.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react'
 
+import { SERVICES_CONTENTS } from '../ServiceContents/ServiceContents'
+
 import { ServiceContent } from './ServiceContent'
 
 test('renders ServiceContent component', () => {
-  render(<ServiceContent />)
+  render(<ServiceContent {...SERVICES_CONTENTS[3]!} />)
 
   const titleElement = screen.getByRole('heading', { level: 1, name: /ServiceContent Component/i })
 

--- a/src/app/_components/Common/ServiceContent/ServiceContent.tsx
+++ b/src/app/_components/Common/ServiceContent/ServiceContent.tsx
@@ -1,5 +1,18 @@
-import { FC } from 'react'
+import React, { FC } from 'react'
 
-export const ServiceContent: FC = () => {
-  return <div> serviceContent </div>
+import { Card, CardContent } from '@/components/ui/card'
+
+export type ServiceContentProps = {
+  icon: React.ReactNode
+  content: React.ReactNode
+}
+export const ServiceContent: FC<ServiceContentProps> = ({ icon, content }) => {
+  return (
+    <Card className="w-full bg-nav">
+      <CardContent className="font-ZenKakuGothicAnitique text-lg">
+        <div className="py-4">{icon}</div>
+        {content}
+      </CardContent>
+    </Card>
+  )
 }

--- a/src/app/_components/Common/ServiceContents/ServiceContents.stories.tsx
+++ b/src/app/_components/Common/ServiceContents/ServiceContents.stories.tsx
@@ -1,0 +1,15 @@
+import { ServiceContents } from './ServiceContents'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+type T = typeof ServiceContents
+
+export default {
+  component: ServiceContents
+} satisfies Meta<T>
+
+type Story = StoryObj<T>
+
+export const Default: Story = {
+  args: {}
+}

--- a/src/app/_components/Common/ServiceContents/ServiceContents.test.tsx
+++ b/src/app/_components/Common/ServiceContents/ServiceContents.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+
+import { ServiceContents } from './ServiceContents'
+
+test('renders ServiceContents component', () => {
+  render(<ServiceContents />)
+
+  const titleElement = screen.getByRole('heading', { level: 1, name: /ServiceContents Component/i })
+
+  expect(titleElement).toBeInTheDocument()
+})

--- a/src/app/_components/Common/ServiceContents/ServiceContents.tsx
+++ b/src/app/_components/Common/ServiceContents/ServiceContents.tsx
@@ -1,0 +1,58 @@
+import { FC } from 'react'
+import { Wrench, Truck, Hammer, Trees } from 'lucide-react'
+
+import { ServiceContent } from '../ServiceContent/ServiceContent'
+
+// Services：営業内容
+export const SERVICES_CONTENTS = [
+  {
+    icon: <Wrench />,
+    content: (
+      <p>
+        機械工具及び省力化機器
+        <br />
+        伝動機器の販売
+      </p>
+    )
+  },
+  {
+    icon: <Truck />,
+    content: (
+      <p>
+        物流、機送機器及び
+        <br />
+        各種工場設備機器の販売
+      </p>
+    )
+  },
+  {
+    icon: <Hammer />,
+    content: (
+      <p>
+        各種機械加工及び
+        <br />
+        板金・溶接加工
+      </p>
+    )
+  },
+  {
+    icon: <Trees />,
+    content: (
+      <p>
+        各種ゴム製品加工及び
+        <br />
+        樹脂成型加工
+      </p>
+    )
+  }
+]
+
+export const ServiceContents: FC = () => {
+  return (
+    <div className="flex w-full justify-between space-x-8 p-4">
+      {SERVICES_CONTENTS.map((service, index) => (
+        <ServiceContent {...service} key={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,14 @@
 import { Header } from './_components/Common/Header/Header'
-import { ServiceContent } from './_components/Common/ServiceContent/ServiceContent'
 import { Suppliers } from './_components/Common/Suppliers/SuppliersContainer'
 import { Products } from './_components/Common/Products/ProductsContainer'
 import { CompanyProfile } from './_components/Common/CompanyProfile/CompanyProfile'
 import { Footer } from './_components/Common/Footer/Footer'
+import { ServiceContents } from './_components/Common/ServiceContents/ServiceContents'
 
 const Sections = [
   {
     name: '営業内容',
-    component: <ServiceContent />
+    component: <ServiceContents />
   },
   {
     name: '取引先メーカー',
@@ -31,7 +31,7 @@ export default function Home() {
       <div className="flex w-full flex-col items-center justify-center px-40 py-8">
         {Sections.map((section, index) => (
           <section className="flex w-full flex-col items-start justify-start py-4" id={section.name} key={index}>
-            <h1 className="p-4 font-ZenKakuGothicAnitique text-lg font-bold">{section.name}</h1>
+            <h1 className="p-4 font-ZenKakuGothicAnitique text-xl font-bold">{section.name}</h1>
             {section.component}
           </section>
         ))}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/tailwindcss/utils'
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div className={cn('rounded-xl border bg-card text-card-foreground shadow', className)} ref={ref} {...props} />
+))
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div className={cn('flex flex-col space-y-1.5 p-6', className)} ref={ref} {...props} />
+  )
+)
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 className={cn('font-semibold leading-none tracking-tight', className)} ref={ref} {...props} />
+  )
+)
+CardTitle.displayName = 'CardTitle'
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p className={cn('text-sm text-muted-foreground', className)} ref={ref} {...props} />
+  )
+)
+CardDescription.displayName = 'CardDescription'
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div className={cn('p-6 pt-0', className)} ref={ref} {...props} />
+)
+CardContent.displayName = 'CardContent'
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div className={cn('flex items-center p-6 pt-0', className)} ref={ref} {...props} />
+)
+CardFooter.displayName = 'CardFooter'
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/constant/text_constants.ts
+++ b/src/constant/text_constants.ts
@@ -8,26 +8,6 @@ export const SITE_SECTIONS = {
 }
 export const CONTACT = 'お問い合わせ'
 
-// Services：営業内容
-export const SERVICES = [
-  {
-    icon: '✏️',
-    content: '機械工具及び省力化機器\n伝動機器の販売'
-  },
-  {
-    icon: '🚚',
-    content: '物流、機送機器及び\n各種工場設備機器の販売'
-  },
-  {
-    icon: '⛴',
-    content: '各種機械加工及び\n板金・溶接加工'
-  },
-  {
-    icon: '🌐',
-    content: '各種ゴム製品加工及び\n樹脂成型加工'
-  }
-]
-
 // Suppliers: 取引先
 export const ALPHABETICAL_ORDER_TABS = [
   'All',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,10 +14,11 @@ const config = {
     },
     extend: {
       fontSize: {
-        mini: '12px',
+        sm: '12px',
         base: '16px',
-        lg: '32px',
-        xl: '64px'
+        lg: '24px',
+        xl: '32px',
+        '2xl': '64px'
       },
       fontFamily: {
         ZenKakuGothicAnitique: ['var(--font-ZenKakuGothicAnitique)'],


### PR DESCRIPTION
## 関連：issue・Ticket
#21
## 概要
(やったことを書く)
ServiceContentsセクションの追加
## 変更点
### パッケージの追加
- lucide-icon

### 追加したSectionのプレビュー
![image](https://github.com/Fukuemon/corp-site/assets/110335987/25db7594-f251-4015-892a-cb9f0deb54a2)


## セルフチェック観点

- [ ] テストの導入
- [ ] buildの確認
- [ ] StorybookでのUI確認

## 今後やること

- [ ] 取引先メーカーの追加
- [ ]
- [ ]

## UIの変更

(UIに関する変更がある場合は、スクリーンショットを貼り付ける)
| ファイル名 | 変更前 | 変更後 |
| --- | --- | --- |
|ServiceContent | | ![image](https://github.com/Fukuemon/corp-site/assets/110335987/f4d3b5e0-6d6e-4616-b2ab-40efb0420256)|
|ServiceContents | |![image](https://github.com/Fukuemon/corp-site/assets/110335987/95a6693f-2970-49f9-a127-12a77cd635eb) |


## 参考

(参考になった文献などがあれば貼り付ける)
