### PR TITLE
✨ feature: 取引先メーカーセクションの作成 #23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@types/jest": "^29.5.12",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "jotai": "^2.7.1",
         "lucide-react": "^0.358.0",
         "next": "14.1.3",
         "react": "^18",
@@ -3601,9 +3603,59 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -3624,6 +3676,84 @@
         "react": "^16.x || ^17.x || ^18.x"
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
@@ -3631,6 +3761,40 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5602,7 +5766,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.2.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -14330,6 +14494,26 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.7.1.tgz",
+      "integrity": "sha512-bsaTPn02nFgWNP6cBtg/htZhCu4s0wxqoklRHePp6l/vlsypR9eLn7diRliwXYWMXDpPvW/LLA2afI8vwgFFaw==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@types/jest": "^29.5.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "jotai": "^2.7.1",
     "lucide-react": "^0.358.0",
     "next": "14.1.3",
     "react": "^18",

--- a/src/app/_components/Common/GridData/GridData.stories.tsx
+++ b/src/app/_components/Common/GridData/GridData.stories.tsx
@@ -1,0 +1,15 @@
+import { GridData } from './GridData'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+type T = typeof GridData
+
+export default {
+  component: GridData
+} satisfies Meta<T>
+
+type Story = StoryObj<T>
+
+export const Default: Story = {
+  args: {}
+}

--- a/src/app/_components/Common/GridData/GridData.test.tsx
+++ b/src/app/_components/Common/GridData/GridData.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+
+import { GridData } from './GridData'
+
+test('renders GridData component', () => {
+  render(<GridData dataItems={['item1', 'item2', 'item3']} />)
+
+  const titleElement = screen.getByRole('heading', { level: 1, name: /GridData Component/i })
+
+  expect(titleElement).toBeInTheDocument()
+})

--- a/src/app/_components/Common/GridData/GridData.tsx
+++ b/src/app/_components/Common/GridData/GridData.tsx
@@ -8,11 +8,11 @@ type Props = {
 
 export const GridData: FC<Props> = ({ dataItems }) => {
   return (
-    <ScrollArea className="grid h-[400px] p-8">
+    <ScrollArea className="grid h-[400px] border-2 shadow-md">
       <div className="grid grid-cols-3 gap-4">
         {dataItems.map((item, index) => (
           <div
-            className="py-4 text-center font-ZenKakuGothicAnitique text-lg  font-extrabold text-foreground"
+            className="py-4 text-center font-ZenKakuGothicAnitique text-base font-extrabold text-foreground md:text-lg"
             key={index}
           >
             {item}

--- a/src/app/_components/Common/GridData/GridData.tsx
+++ b/src/app/_components/Common/GridData/GridData.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react'
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+type Props = {
+  dataItems: string[]
+}
+
+export const GridData: FC<Props> = ({ dataItems }) => {
+  return (
+    <ScrollArea className="grid h-[400px] p-8">
+      <div className="grid grid-cols-3 gap-4">
+        {dataItems.map((item, index) => (
+          <div
+            className="py-4 text-center font-ZenKakuGothicAnitique text-lg  font-extrabold text-foreground"
+            key={index}
+          >
+            {item}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}

--- a/src/app/_components/Common/NavigationBar/NavigationBarPresenter.tsx
+++ b/src/app/_components/Common/NavigationBar/NavigationBarPresenter.tsx
@@ -18,7 +18,7 @@ export const NavigationBarPresenter: FC<NavigationBar> = (props) => {
           <h1 className="text-xl font-extrabold">{props.companyName}</h1>
         </Link>
         {/* 右サイド */}
-        <div className="flex items-center space-x-10">
+        <div className="flex items-center space-x-10 font-ZenKakuGothicAnitique">
           {props.rightTabs.map((tab, index) => (
             <Link className="text-base font-medium hover:text-gray-300" href={`#${tab}`} key={index}>
               {tab}

--- a/src/app/_components/Common/Suppliers/Suppliers.stories.tsx
+++ b/src/app/_components/Common/Suppliers/Suppliers.stories.tsx
@@ -1,3 +1,5 @@
+import { suppliers } from '@/constant/suppliers'
+
 import { SuppliersPresenter } from './SuppliersPresenter'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -11,5 +13,5 @@ export default {
 type Story = StoryObj<T>
 
 export const Default: Story = {
-  args: {}
+  args: { displayData: suppliers }
 }

--- a/src/app/_components/Common/Suppliers/SuppliersContainer.tsx
+++ b/src/app/_components/Common/Suppliers/SuppliersContainer.tsx
@@ -1,11 +1,13 @@
+'use client'
 import { FC } from 'react'
 
+import { suppliers } from '@/constant/suppliers'
+
 import { SuppliersPresenter } from './SuppliersPresenter'
+import { useSortedFilteredSuppliers } from './useSortedFilterdSuppliers'
 
 export const Suppliers: FC = () => {
-  return (
-    <div>
-      <SuppliersPresenter suppliers="suppliers" />
-    </div>
-  )
+  const displayData = useSortedFilteredSuppliers(suppliers)
+
+  return <SuppliersPresenter displayData={displayData} />
 }

--- a/src/app/_components/Common/Suppliers/SuppliersPresenter.tsx
+++ b/src/app/_components/Common/Suppliers/SuppliersPresenter.tsx
@@ -1,9 +1,18 @@
 import { FC } from 'react'
 
-type Props = {
-  suppliers: string
-}
+import { SupplierProps } from '@/constant/suppliers'
 
-export const SuppliersPresenter: FC<Props> = ({ suppliers }) => {
-  return <div>{suppliers}</div>
+import TabsContainer from '../Tabs/TabsContainer'
+import { GridData } from '../GridData/GridData'
+
+type SuppliersPresenterProps = {
+  displayData: SupplierProps[]
+}
+export const SuppliersPresenter: FC<SuppliersPresenterProps> = ({ displayData }) => {
+  return (
+    <div className="flex w-full flex-col">
+      <TabsContainer />
+      <GridData dataItems={displayData.map((supplier) => supplier.name)} />
+    </div>
+  )
 }

--- a/src/app/_components/Common/Suppliers/useSortedFilterdSuppliers.ts
+++ b/src/app/_components/Common/Suppliers/useSortedFilterdSuppliers.ts
@@ -1,0 +1,24 @@
+import { useAtom } from 'jotai'
+
+import { SupplierProps } from '@/constant/suppliers'
+
+import { selectedTabAtom } from '../Tabs/tabDataAtom'
+
+export const useSortedFilteredSuppliers = (suppliers: SupplierProps[]): SupplierProps[] => {
+  const [selectedTab] = useAtom(selectedTabAtom)
+
+  // alphabeticalカテゴリと会社名でソート
+  const sortedData = suppliers.slice().sort((a, b) => {
+    const categoryCompare = a.alphabetical.localeCompare(b.alphabetical, 'ja')
+    if (categoryCompare !== 0) return categoryCompare
+    return a.name.localeCompare(b.name, 'ja')
+  })
+
+  // 選択されたタブが 'All' の場合は全データを返す
+  if (selectedTab === 'All') {
+    return sortedData
+  }
+
+  // 選択されたタブに応じてデータをフィルタリング
+  return sortedData.filter((item) => item.alphabetical === selectedTab)
+}

--- a/src/app/_components/Common/Tabs/Tabs.stories.tsx
+++ b/src/app/_components/Common/Tabs/Tabs.stories.tsx
@@ -1,0 +1,15 @@
+import TabsPresenter from './TabsPresenter'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+type T = typeof TabsPresenter
+
+export default {
+  component: TabsPresenter
+} satisfies Meta<T>
+
+type Story = StoryObj<T>
+
+export const Default: Story = {
+  args: {}
+}

--- a/src/app/_components/Common/Tabs/Tabs.test.tsx
+++ b/src/app/_components/Common/Tabs/Tabs.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+
+import Tabs from './TabsContainer'
+
+test('renders Tabs component', () => {
+  render(<Tabs />)
+
+  const titleElement = screen.getByRole('heading', { level: 1, name: /Tabs Component/i })
+
+  expect(titleElement).toBeInTheDocument()
+})

--- a/src/app/_components/Common/Tabs/TabsContainer.tsx
+++ b/src/app/_components/Common/Tabs/TabsContainer.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useAtom } from 'jotai'
+
+import { tabDataAtom, selectedTabAtom } from './tabDataAtom'
+import TabsPresenter from './TabsPresenter'
+
+const TabsContainer: React.FC = () => {
+  const [tabData] = useAtom(tabDataAtom)
+  const [selectedTab, setSelectedTab] = useAtom(selectedTabAtom)
+
+  const handleSelectTab = (tab: string) => {
+    setSelectedTab(tab)
+  }
+
+  return <TabsPresenter onSelectTab={handleSelectTab} selectedTab={selectedTab} tabData={tabData} />
+}
+
+export default TabsContainer

--- a/src/app/_components/Common/Tabs/TabsPresenter.tsx
+++ b/src/app/_components/Common/Tabs/TabsPresenter.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+type TabsPresenterProps = {
+  tabData: string[]
+  selectedTab: string
+  onSelectTab: (tab: string) => void
+}
+
+const TabsPresenter: React.FC<TabsPresenterProps> = ({ tabData, selectedTab, onSelectTab }) => (
+  <div className="flex items-center justify-between  border-b">
+    {tabData.map((tab) => (
+      <button
+        className={`px-4 py-2 text-center text-lg font-medium ${
+          tab === selectedTab
+            ? 'border-b-2 border-primary  text-primary'
+            : 'border-b-2 border-transparent text-gray-400  hover:border-primary hover:text-primary'
+        }`}
+        key={tab}
+        onClick={() => onSelectTab(tab)}
+      >
+        {tab}
+      </button>
+    ))}
+  </div>
+)
+
+export default TabsPresenter

--- a/src/app/_components/Common/Tabs/tabDataAtom.tsx
+++ b/src/app/_components/Common/Tabs/tabDataAtom.tsx
@@ -1,0 +1,4 @@
+import { atom } from 'jotai'
+
+export const tabDataAtom = atom(['All', 'あ行', 'か行', 'さ行', 'た行', 'な行', 'は行', 'ま行', 'や行', 'ら行', 'わ行'])
+export const selectedTabAtom = atom('All')

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import * as React from 'react'
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
+
+import { cn } from '@/lib/tailwindcss/utils'
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root className={cn('relative overflow-hidden', className)} ref={ref} {...props}>
+    <ScrollAreaPrimitive.Viewport className="size-full rounded-[inherit]">{children}</ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    className={cn(
+      'flex touch-none select-none transition-colors',
+      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
+      orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+      className
+    )}
+    orientation={orientation}
+    ref={ref}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/constant/suppliers.ts
+++ b/src/constant/suppliers.ts
@@ -1,0 +1,1489 @@
+export type SupplierProps = {
+  name: string
+  alphabetical: string
+  category?: string
+  url?: string
+}
+
+export const suppliers: SupplierProps[] = [
+  {
+    name: '（株）キッツ',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '日立バルブ（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）ヨシタケ',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）フジキン',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）フジトク',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '大阪サニタリィー金属工業協同組合',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '日立金属（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'シーケー金属（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'イノック（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '古林工業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '旭有機材工業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '積水化学工業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）いけうち',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'スプレイングシステムジャパン（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）カクダイ',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '昌栄産業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'トーフレ（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'シヨーボンドカップリング（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）昭和技研工業',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'イハラサイエンス（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'フローバル（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '東拓工業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'カナフレックスコーポレーション（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）トヨックス',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '十川産業（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '日本ブッシュ（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）荏原製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）鶴見製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'テラル（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）酉島製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'な'
+  },
+  {
+    name: '（株）丸八ポンプ',
+    category: 'ポンプ関連機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '久喜ポンプ工業（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'グルンドフォスポンプ株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'ギャーエス工業（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）日立産機システム',
+    category: 'ポンプ関連機器,荷役・搬送機器,ファンブロア及び産業機器,駆動・変減速機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）寺田ポンプ製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'セイコー化工機（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）タクミナ',
+    category: 'ポンプ関連機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）工進',
+    category: 'ポンプ関連機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）イワキ',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'エレポン化工機（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）アンレット',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'オリオン機械（株）',
+    category: 'ポンプ関連機器,工場設備関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）大阪空気機械製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '神港精機（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '有光工業（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）キョーワ',
+    category: 'ポンプ関連機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'マルヤマエクセル（株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '三浦工業株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '兵神装備株）',
+    category: 'ポンプ関連機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）花塚製作所',
+    category: 'ポンプ関連機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）ヤマダコーポレーション',
+    category: 'ポンプ関連機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）マキテック',
+    category: '荷役・搬送機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'オークラ輸送機（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'マルヤス機械（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '三機工業（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'セントラルコンベア（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）メイキコウ',
+    category: '荷役・搬送機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '三和コンベア（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）日工',
+    category: '荷役・搬送機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '三洋機械産業（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '伊東電機（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）協和製作所',
+    category: '荷役・搬送機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'ニッタ（株）',
+    category: '荷役・搬送機器,チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'な行'
+  },
+  {
+    name: '宇部樹脂加工（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）椿本バルクシステム',
+    category: '荷役・搬送機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）フリーベアコーポレイション',
+    category: '荷役・搬送機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）井口機構製作所',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）富士製作所',
+    category: '荷役・搬送機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）大日ハンソー',
+    category: '荷役・搬送機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'エクセン（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）スリーエッチ',
+    category: '荷役・搬送機器,材料・ボルト関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）キトー',
+    category: '荷役・搬送機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '象印チェンブロック（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）ニッチ',
+    category: '荷役・搬送機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）ダイフク',
+    category: '荷役・搬送機器,工場設備関連',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'ハンマーキャスター（株）',
+    category: '荷役・搬送機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）ナンシン',
+    category: '荷役・搬送機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）内村製作所',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）ヨドノ',
+    category: '荷役・搬送機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）岡本工機',
+    category: '荷役・搬送機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）永瀬工場',
+    category: '荷役・搬送機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'トラスコ中山（株）',
+    category: '工場設備関連,ツーリング・治具,研削・研磨用品',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）サカエ',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）河原',
+    category: '工場設備関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）スギヤス',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '鈴木製機（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）をくだ屋技研',
+    category: '工場設備関連',
+    alphabetical: 'わ行'
+  },
+  {
+    name: 'ワタベ産業（株）',
+    category: '工場設備関連',
+    alphabetical: 'わ行'
+  },
+  {
+    name: '（株）淀川製鋼所.',
+    category: '工場設備関連',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）大阪タイユーストラパック',
+    category: '工場設備関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '文化シャッター（株）',
+    category: '工場設備関連',
+    alphabetical: 'は行'
+  },
+  {
+    name: '三甲（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'アイリスオオヤマ（株）',
+    category: '工場設備関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'リス（株）',
+    category: '工場設備関連',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '（株）テイモー',
+    category: '工場設備関連',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'サンキン（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'スイコー（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'コクヨ（株）',
+    category: '工場設備関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）ナイキ',
+    category: '工場設備関連',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'アズワン（株）',
+    category: '工場設備関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'コマニー（株）',
+    category: '工場設備関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '生興（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）協和製作所',
+    category: '工場設備関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '三進金属工業（株）',
+    category: '工場設備関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '日成ビルド工業（株）',
+    category: '工場設備関連',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'ダイキン工業（株）',
+    category: '工場設備関連,空圧・油圧機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）コロナ',
+    category: '工場設備関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'フルタ電機（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '昭和電機（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）スイデンテラル（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '新東工業（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: 'アマノ（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'リョウセイ（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '三立機器（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '淀川電機製作所',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）高木鉄工所',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'コベルココンプレッサー（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'アネスト岩田（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '三井精機工業（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）明治機器製作所',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '虹技（株）',
+    category: 'ファンブロア及び産業機器,材料・ボルト関連',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）竹綱製作所',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）八光電機',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '新日電熱工業（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '厚地鉄工所（株）',
+    category: 'ファンブロア及び産業機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '住友重機械工業（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '三菱電機（株）',
+    category: '駆動・変減速機器,自動化・省力化機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）ツバキエマソン',
+    category: '駆動・変減速機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）ニッセイ',
+    category: '駆動・変減速機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'オリエンタルモーター（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'パナソニック（株）',
+    category: '駆動・変減速機器,電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日本電産シンポ（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '三木プーリー（株）',
+    category: '駆動・変減速機器,伝動機器・用品',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）マキシンコー',
+    category: '駆動・変減速機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）酒井製作所',
+    category: '駆動・変減速機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）長谷川鉄工所',
+    category: '駆動・変減速機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '青木精密工業（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'SEWオイドライブジャパン（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '東芝産業機器システム（株）',
+    category: '駆動・変減速機器,自動化・省力化機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '富士電機（株）',
+    category: '駆動・変減速機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）安川電機',
+    category: '駆動・変減速機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: 'NTN（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'THK（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '日本精工（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）不二越',
+    category: '軸受・直動機器,自動化・省力化機器,空圧・油圧機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日本トムソン（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '旭精工（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '日本ベアリング（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）ツバキナカシマ',
+    category: '軸受・直動機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'オザック精工（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'イグス（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'オイレス工業（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '東洋シャフト（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '森本精密シャフト（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '大同メタル工業（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'ミネベア（株）',
+    category: '軸受・直動機器,自動化・省力化機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'NOK（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '新日本オイルシール（株）',
+    category: '軸受・直動機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）東洋オイルシール製作所',
+    category: '軸受・直動機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）富士精密',
+    category: '軸受・直動機器,材料・ボルト関連',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）アイエイアイ',
+    category: '自動化・省力化機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）デジタル',
+    category: '自動化・省力化機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'オムロン（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '松下制御機器（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'アズビル（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '三洋電機（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '日東工業（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '富士電機機器制株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）エー・アンド・デイ',
+    category: '自動化・省力化機器,測定・計測機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'ファナック（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）ハーモニック・ドライブ・システムズ',
+    category: '自動化・省力化機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: 'IDEC（株）',
+    category: '自動化・省力化機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）椿本チェイン',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'た行'
+  },
+  {
+    name: '日立機材（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'な行'
+  },
+  {
+    name: '片山チェイン（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'か行'
+  },
+  {
+    name: '日本チェイン（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'な行'
+  },
+  {
+    name: '鳥羽チェイン（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'た行'
+  },
+  {
+    name: '三ツ星ベルト（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車,伝動機器・用品,材料・ボルト関連',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'バンドー化学（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日本ジークリング（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'な行'
+  },
+  {
+    name: '小原歯車工業（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '協育歯車工業株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'か行'
+  },
+  {
+    name: '関西金網（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）デイコム',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'た行'
+  },
+  {
+    name: '鍋屋バイテック（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車,伝動機器・用品',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）大三商会',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'ツバキ山久チェイン（株）',
+    category: 'チェーン・ベルト及びスプロケット・歯車',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）イマオコーポレーション',
+    category: '伝動機器・用品',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）岩田製作所',
+    category: '伝動機器・用品',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）セイサ',
+    category: '伝動機器・用品',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）三好キカイ',
+    category: '伝動機器・用品',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '倉敷化工（株）',
+    category: '伝動機器・用品',
+    alphabetical: 'か行'
+  },
+  {
+    name: '神鋼電機（株）',
+    category: '伝動機器・用品',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '日本ギヤー工業（株）',
+    category: '伝動機器・用品',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）昌和発条製作所',
+    category: '伝動機器・用品',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '阪神発條株）',
+    category: '伝動機器・用品',
+    alphabetical: 'は行'
+  },
+  {
+    name: '東洋ゴム工業株）',
+    category: '伝動機器・用品',
+    alphabetical: 'と行'
+  },
+  {
+    name: 'アイセル（株）',
+    category: '伝動機器・用品',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '太陽工機（株）',
+    category: '伝動機器・用品',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'SMC（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'CKD（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）コガネイ',
+    category: '空圧・油圧機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）TAIYO',
+    category: '空圧・油圧機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'クロダニューマテイクス（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）日本ピスコ',
+    category: '空圧・油圧機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）ニューエラー',
+    category: '空圧・油圧機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）妙徳',
+    category: '空圧・油圧機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'KYB（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '理研機器（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '油研工業（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: 'アプライトパワージャパン（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）堀内機械',
+    category: '空圧・油圧機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '神威産業（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'か行'
+  },
+  {
+    name: '日本オイルポンプ（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）ブリジストン',
+    category: '空圧・油圧機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '大生工業（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '日本精器（株）',
+    category: '空圧・油圧機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'エヌアイシー・オートテック（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'クオドラントポリペンコジャパン（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '双葉電子工業（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'は行'
+  },
+  {
+    name: '大同アシスター（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'だ行'
+  },
+  {
+    name: '伊東鋳工株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '作新工業（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）大和螺子',
+    category: '材料・ボルト関連',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）コノエ',
+    category: '材料・ボルト関連',
+    alphabetical: 'か行'
+  },
+  {
+    name: '東北ネジ製造（株）',
+    category: '材料・ボルト関連',
+    alphabetical: 'た行'
+  },
+  {
+    name: '三菱マテリアルツールズ（株）',
+    category: '切削工具',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '日立ツールズ（株）',
+    category: '切削工具',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'オーエスジー（株）',
+    category: '切削工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '岡崎精工（株）',
+    category: '切削工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '京セラ（株）',
+    category: '切削工具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）ニコテック',
+    category: '切削工具',
+    alphabetical: 'な行'
+  },
+  {
+    name: '谷口工業（株）',
+    category: '切削工具',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）ミヤナガ',
+    category: '切削工具',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）弥満和製作所',
+    category: '切削工具',
+    alphabetical: 'や行'
+  },
+  {
+    name: 'ノガ・ジャパン',
+    category: '切削工具',
+    alphabetical: 'な行'
+  },
+  {
+    name: '富士元工業株',
+    category: '切削工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '大見工業（株）',
+    category: '切削工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: 'エムアールテイ（株）',
+    category: '切削工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）ラキ',
+    category: '切削工具',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '（株）ミツトヨ',
+    category: '測定・計測機器',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'シンワ測定（株）',
+    category: '測定・計測機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '株）TJMデザイン',
+    category: '測定・計測機器',
+    alphabetical: 'た行'
+  },
+  {
+    name: '大西測定（株）',
+    category: '測定・計測機器',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '新潟精機（株）',
+    category: '測定・計測機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）中村製作所',
+    category: '測定・計測機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）第一計器製作所',
+    category: '測定・計測機器',
+    alphabetical: 'だ行'
+  },
+  {
+    name: '長野計器（株）',
+    category: '測定・計測機器',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）佐藤計量器製作所',
+    category: '測定・計測機器',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '大和製衡（株）',
+    category: '測定・計測機器',
+    alphabetical: 'や行'
+  },
+  {
+    name: '日置電機（株）',
+    category: '測定・計測機器',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日立工機（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日本ヒルティー（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '日東工器（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）マキタ',
+    category: '電動・油空圧工具',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '（株）やまびこ',
+    category: '電動・油空圧工具',
+    alphabetical: 'や行'
+  },
+  {
+    name: 'ボッシュ（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: 'レッキス工業（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '（株）ロブテックス',
+    category: '電動・油空圧工具,作業工具',
+    alphabetical: 'ら行'
+  },
+  {
+    name: '（株）ベッセル',
+    category: '電動・油空圧工具,作業工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '不二空機株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '瓜生製作（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）空研',
+    category: '電動・油空圧工具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '日本ニューマチック工業（株）',
+    category: '電動・油空圧工具',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）北川鉄工所',
+    category: 'ツーリング・治具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '大昭和精機（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）ニューストロング',
+    category: 'ツーリング・治具',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'ユキワ精工（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'や行'
+  },
+  {
+    name: 'カトウ工機（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'か行'
+  },
+  {
+    name: 'エヌテイツール（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '（株）日研工作所',
+    category: 'ツーリング・治具',
+    alphabetical: 'な行'
+  },
+  {
+    name: '津田駒工業（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'カネテック（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '（株）テクノプラン',
+    category: 'ツーリング・治具',
+    alphabetical: 'た行'
+  },
+  {
+    name: '扶桑精機（株）',
+    category: 'ツーリング・治具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '（株）スーパーツール',
+    category: 'ツーリング・治具,作業工具',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '日本レジボン（株）',
+    category: '研削・研磨用品',
+    alphabetical: 'な行'
+  },
+  {
+    name: 'ニューレジストン（株）',
+    category: '研削・研磨用品',
+    alphabetical: 'な行'
+  },
+  {
+    name: '（株）イチグチ',
+    category: '研削・研磨用品',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '住友スリーエム（株）',
+    category: '研削・研磨用品',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '柳瀬（株）',
+    category: '研削・研磨用品',
+    alphabetical: 'や行'
+  },
+  {
+    name: '（株）オフィスマイン',
+    category: '研削・研磨用品',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '三共理化学（株）',
+    category: '研削・研磨用品',
+    alphabetical: 'さ行'
+  },
+  {
+    name: '（株）大陽商会',
+    category: '研削・研磨用品',
+    alphabetical: 'た行'
+  },
+  {
+    name: '（株）ムラキ',
+    category: '研削・研磨用品',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '前田金属工業株）',
+    category: '作業工具',
+    alphabetical: 'ま行'
+  },
+  {
+    name: '京都機械工具株）',
+    category: '作業工具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '角田興業（株）',
+    category: '作業工具',
+    alphabetical: 'か行'
+  },
+  {
+    name: '大同興業（株）',
+    category: '作業工具',
+    alphabetical: 'た行'
+  },
+  {
+    name: 'ホーザン（株）',
+    category: '作業工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '室本鉄工（株）',
+    category: '作業工具',
+    alphabetical: 'ま行'
+  },
+  {
+    name: 'オーエッチ工業（株）',
+    category: '作業工具',
+    alphabetical: 'あ行'
+  },
+  {
+    name: '花園工具（株）',
+    category: '作業工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: 'フジ矢（株）',
+    category: '作業工具',
+    alphabetical: 'は行'
+  },
+  {
+    name: '浦谷商亊（株）',
+    category: 'バルブ・ホース配管機器',
+    alphabetical: 'う行'
+  }
+]

--- a/src/constant/suppliers.ts
+++ b/src/constant/suppliers.ts
@@ -247,12 +247,12 @@ export const suppliers: SupplierProps[] = [
     alphabetical: 'ま行'
   },
   {
-    name: '三浦工業株）',
+    name: '三浦工業（株）',
     category: 'ポンプ関連機器',
     alphabetical: 'ま行'
   },
   {
-    name: '兵神装備株）',
+    name: '兵神装備（株）',
     category: 'ポンプ関連機器',
     alphabetical: 'は行'
   },


### PR DESCRIPTION
## 関連：issue・Ticket
#23 
## 概要
五十音順でフィルター可能な取引先メーカーセクションを作成


## 変更点

### 新規コンポーネント
- タブバー：Tabs
- データを表示するためのスクロール可能なグリッド：GridData

## セルフチェック観点

- [ ] テストの導入
- [ ] buildの確認
- [ ] StorybookでのUI確認

## 今後やること

- [ ] 製品カテゴリのセクション作成
- [ ] フッターの作成
- [ ]

## UIの変更

(UIに関する変更がある場合は、スクリーンショットを貼り付ける)
| ファイル名 | 変更前 | 変更後 |
| --- | --- | --- |
|Tabs.tsx| | <img width="1174" alt="image" src="https://github.com/Fukuemon/corp-site/assets/110335987/779df88f-d1de-4f40-bb38-7af10b2f56c8">|
|GridData.tsx| | <img width="1162" alt="image" src="https://github.com/Fukuemon/corp-site/assets/110335987/df9eac62-0d56-4380-aded-231608a0e9db">|
|Suppliers.tsx| | <img width="1470" alt="image" src="https://github.com/Fukuemon/corp-site/assets/110335987/0ace6753-e9c6-425e-9ffd-db0d53a4f446">|

## 参考

(参考になった文献などがあれば貼り付ける)
